### PR TITLE
Updates GPG verification task to use two-arg format

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,14 @@
       url: "{{ paxctld_sig_url }}"
       dest: "{{ paxctld_download_directory }}/{{ paxctld_filename }}.sig"
 
+# Intentionally using the verbose two-arg format for `gpg --verify`.
+# The manpage stipulates that explicitly providing the detached signature
+# file, then the filename to be verified is the safest invocation.
 - name: Verify paxctld package GPG signature.
-  command: gpg --verify {{ paxctld_download_directory }}/{{ paxctld_filename }}.sig
+  command: >
+    gpg --verify
+    {{ paxctld_download_directory }}/{{ paxctld_filename }}.sig
+    {{ paxctld_download_directory }}/{{ paxctld_filename }}
   register: gpg_verify_result
   changed_when: false
 


### PR DESCRIPTION
The GPG manpage stipulates that the `gpg --verify`, when used with a detached signature file, should explicitly declare the signature file and then the target file to be verified, e.g.:

`gpg --verify <sig> <file>`

It's easy to do this instead:

`gpg --verify <sig>`

but technically the latter approach can report false positives. Closes #1.
