### PR TITLE
Supports --check mode via always_run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
     {{ paxctld_download_directory }}/{{ paxctld_filename }}.sig
     {{ paxctld_download_directory }}/{{ paxctld_filename }}
   register: gpg_verify_result
+  always_run: true
   changed_when: false
 
 # Write config file prior to installing package, so desired flags are set immediately.


### PR DESCRIPTION
The GPG verification task will error out if it tries to reference a
registered var that was never defined. Therefore run the task that
registers the var, since it's read-only and permits dry runs of the
role.
