### PR TITLE
Idempotent installation of deb package

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installs paxctld
   company: Freedom of the Press Foundation (@FreedomofPress)
   license: MIT
-  min_ansible_version: 1.9.4
+  min_ansible_version: 2
   platforms:
     - name: Debian
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,10 +41,7 @@
   become: yes
   apt:
     deb: "{{ paxctld_download_directory }}/{{ paxctld_filename }}"
-    dpkg_options: skip-same-version,force-confdef,force-confold
   when: "'Good signature' in gpg_verify_result.stderr"
-  register: paxctld_install_result
-  changed_when: "'dpkg: version {{ paxctld_version }} of paxctld already installed' not in paxctld_install_result.stderr"
 
 - name: Restart paxctld and ensure it is enabled.
   become: yes


### PR DESCRIPTION
The Ansible apt module is smart enough to handle "changed" status
correctly when using the "deb" parameter, so we don't need special logic
referencing registered vars.
