### PR TITLE
Cleanup storage of paxctld ansible variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,23 +10,11 @@ paxctld_gpg_keyserver: hkps.pool.sks-keyservers.net
 # including items you want to preserve. In particular consider retaining the python
 # config, as it's necessary for Ansible to run.
 paxctld_configs:
-  - binary: /usr/bin/python2.7
-    flags: m
-  - binary: /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
-    flags: m
-  - binary: /usr/bin/nodejs
-    flags: m
-  - binary: /usr/bin/node
-    flags: m
-  - binary: /usr/sbin/asterisk
-    flags: m
-  - binary: /opt/kibana/node/bin/node
-    flags: m
-  - binary: /usr/bin/grub-script-check
-    flags: pm
-  - binary: /usr/bin/grub-bios-setup
-    flags: pm
-  - binary: /usr/sbin/grub-mkdevicemap
-    flags: pm
-  - binary: /usr/sbin/grub-probe
-    flags: pm
+  /usr/bin/grub-bios-setup: mp
+  /usr/bin/grub-script-check: mp
+  /usr/bin/node: m
+  /usr/bin/nodejs: m
+  /usr/bin/python2.7: m
+  /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java: m
+  /usr/sbin/grub-mkdevicemap: mp
+  /usr/sbin/grub-probe: mp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
     src: paxctld.conf.j2
     dest: /etc/paxctld.conf
   notify: restart paxctld
+  tags: ['updatepaxctld']
 
 - name: Install paxctld deb package.
   become: yes

--- a/templates/paxctld.conf.j2
+++ b/templates/paxctld.conf.j2
@@ -1,3 +1,3 @@
-{% for config in paxctld_configs %}
-{{ config.binary }}	{{ config.flags }}
+{% for binary, flags in paxctld_configs|dictsort %}
+{{ binary }}   {{ flags }}
 {% endfor %}


### PR DESCRIPTION
Converted current list structure:

```yaml
paxctld_configs:
  - binary: /usr/bin/python2.7
    flags: m
```

to the following structure:
```yaml
paxctld_configs:
  - /usr/bin/python2.7: m
```

This is really just a visual tweak for the human maintainer so the variables are a
little cleaner to look at and append to. I also removed some of the generic
defaults that I figured may not be applicable to all hosts. Next good step for
expansion would to make multiple layers of variables so we have sane defaults,
and hosts can append instead of having to override the entire `paxctld_configs`.