### PR TITLE
Bumps paxctld version to 1.2.2-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 
 ```yaml
 paxctld_download_directory: /usr/local/src
-paxctld_version: "1.2.1-1"
+paxctld_version: "1.2.2-1"
 paxctld_filename: "paxctld_{{ paxctld_version }}_amd64.deb"
 paxctld_deb_url: "https://grsecurity.net/paxctld/{{ paxctld_filename }}"
 paxctld_sig_url: "https://grsecurity.net/paxctld/{{ paxctld_filename }}.sig"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 paxctld_download_directory: /usr/local/src
-paxctld_version: "1.2.1-1"
+paxctld_version: "1.2.2-1"
 paxctld_filename: "paxctld_{{ paxctld_version }}_amd64.deb"
 paxctld_deb_url: "https://grsecurity.net/paxctld/{{ paxctld_filename }}"
 paxctld_sig_url: "https://grsecurity.net/paxctld/{{ paxctld_filename }}.sig"


### PR DESCRIPTION
The URLs for the previous version, 1.2.1-1, now show 404s.